### PR TITLE
Add an handler on the fly

### DIFF
--- a/lib/IO/Tee.pm
+++ b/lib/IO/Tee.pm
@@ -52,6 +52,18 @@ sub handles
     @{*{$_[0]}};
 }
 
+
+# Add an handle (or something else)
+# to the array of handles already known
+# to this tee.
+#
+# Is this concurrent safe?
+sub add
+{
+    my ( $self ) = shift;
+    for ( @_ ) { push @{*$self}, _handle( $_ ); }
+}
+
 # Proxy routines for various IO::Handle and IO::File operations
 
 sub _method_return_success

--- a/lib/IO/Tee.pm
+++ b/lib/IO/Tee.pm
@@ -380,8 +380,9 @@ subsequent output multiplexing fails.
     use IO::Tee;
     use IO::File;
 
-    my $tee = new IO::Tee(\*STDOUT,
-        new IO::File(">tt1.out"), ">tt2.out");
+    my $tee = IO::Tee->new( \*STDOUT,
+                           IO::File->new(">tt1.out"),
+                           ">tt2.out");
 
     $tee->add( IO::File->new( 'tt3.out', 'w') );
     print join(' ', $tee->handles), "\n";
@@ -390,7 +391,7 @@ subsequent output multiplexing fails.
     for (1..10) { $tee->print($_, "\n") }
     $tee->flush;
 
-    $tee = new IO::Tee('</etc/passwd', \*STDOUT);
+    $tee = IO::Tee->new('</etc/passwd', \*STDOUT);
     my @lines = <$tee>;
     print scalar(@lines);
 

--- a/lib/IO/Tee.pm
+++ b/lib/IO/Tee.pm
@@ -383,6 +383,7 @@ subsequent output multiplexing fails.
     my $tee = new IO::Tee(\*STDOUT,
         new IO::File(">tt1.out"), ">tt2.out");
 
+    $tee->add( IO::File->new( 'tt3.out', 'w') );
     print join(' ', $tee->handles), "\n";
 
     for (1..10) { print $tee $_, "\n" }

--- a/t/original.t
+++ b/t/original.t
@@ -7,7 +7,7 @@ BEGIN { $^W = 1 }
 ######################### We start with some black magic to print on failure.
 
 my $loaded;
-BEGIN { $| = 1; print "1..27\n"; }
+BEGIN { $| = 1; print "1..31\n"; }
 END {print "not ok 1\n" unless $loaded;}
 use IO::Tee;
 use IO::File;
@@ -92,6 +92,48 @@ $t3 and ($t3->autoflush(1), $t3->flush)
     print((($contents eq $expected) ? '' : 'not '), "ok 26\n");
 }
 
+# test add method
+{
+    my $tee = IO::Tee->new( '>test.1' );
+    my $expected = 'Testing add';
+
+    my $num_lines   = 5;
+    my $added_lines = 10;
+    print {$tee} "$expected\n" for ( 1..$num_lines );
+
+    $tee->add( '>test.2' );
+    print {$tee} "$expected\n" for( 1..$added_lines );
+    $tee->close;
+    my $fh = IO::File->new( '<test.1' );
+    my $ok_original;
+    my @src_lines = $fh->getlines;
+    $fh->close;
+
+    $fh = IO::File->new( '<test.2' );
+    my @added_lines = $fh->getlines;
+    $fh->close;
+
+    my $ok_lines = ( $#src_lines - $#added_lines ) == $added_lines;
+    print ( ( $ok_lines ? 'not ' : '' ), "ok 27\n" );
+
+    $ok_lines = 1;
+    for ( @added_lines ){
+        undef $ok_lines if ( $_ !~ /^$expected/ );
+    }
+    print (( $ok_lines ? 'not ' : '' ), "ok 28\n");
+
+    $ok_lines = 1;
+    for ( @src_lines ){
+        undef $ok_lines if ( $_ !~ /^$expected/ );
+    }
+    print (( $ok_lines ? 'not ' : '' ), "ok 29\n");
+
+
+    $ok_lines = 1;
+    undef $ok_lines if ( scalar @src_lines != ( $num_lines + $added_lines ) || scalar @added_lines != $added_lines );
+    print (( $ok_lines ? 'not ' : '' ), "ok 30\n");
+}
+
 undef $testfile2; close TEST3; undef $t3;
 5 == unlink 'test.1', 'test.2', 'test.3', 'test.4', 'test.5'
-    and print "ok 27\n" or print "not ok 27\n";
+    and print "ok 31\n" or print "not ok 31\n";


### PR DESCRIPTION
Sometimes I need to add another filehandle to the already running IO::Tee.
This for instance happens when I have to write to multiple locations depending on the parsing of the command options. The solution so far seems to be to destroy the IO::Tee and rebuild it from the previous one.
With this short change I placed an 'add' method that allows for adding a new filehandle (or something alike)) to modify the tee so that it starts sending the output also to such destination.

Tests have been expanded to check it.