### PR TITLE
Make IO::Tee compatible with IO::Wrap (and maybe other IO::* classes).

### DIFF
--- a/lib/IO/Tee.pm
+++ b/lib/IO/Tee.pm
@@ -69,7 +69,7 @@ sub formline
     formline($picture, @_);
 
     my $ret = 1;
-    foreach my $fh (@{*$self}) { undef $ret unless print $fh $^A }
+    foreach my $fh (@{*$self}) { undef $ret unless $fh->print($^A) }
     return $ret;
 }
 
@@ -129,7 +129,7 @@ sub PRINT
 {
     my $self = shift;
     my $ret = 1;
-    foreach my $fh (@$self) { undef $ret unless print $fh @_ }
+    foreach my $fh (@$self) { undef $ret unless $fh->print(@_) }
     return $ret;
 }
 
@@ -138,7 +138,7 @@ sub PRINTF
     my $self = shift;
     my $fmt = shift;
     my $ret = 1;
-    foreach my $fh (@$self) { undef $ret unless printf $fh $fmt, @_ }
+    foreach my $fh (@$self) { undef $ret unless $fh->printf($fmt, @_) }
     return $ret;
 }
 
@@ -150,7 +150,7 @@ sub _multiplex_input
     {
         for (my $i = 1; $i < @$self; ++$i)
         {
-            undef $ret unless print {$self->[$i]} $input;
+            undef $ret unless {$self->[$i]}->print($input);
         }
     }
     $ret;

--- a/t/io-classes.t
+++ b/t/io-classes.t
@@ -1,0 +1,36 @@
+# -*- perl -*-
+#------------------------------------------------------------
+
+# Usage of IO::Tee with IO::* classes, especially IO::Wrap.
+
+use strict;
+use English qw(-no_match_vars);
+
+use Test::More tests => 4;
+
+use IO::Tee;
+
+use File::Temp qw(tmpnam);
+use IO::Wrap;
+use IO::File;
+
+my $wrap_fname = tmpnam();
+open (WRAPF, '>', $wrap_fname)
+  or  die "Could not open $wrap_fname for writing: $ERRNO,";
+my $wrap_fh = wraphandle(\*WRAPF);
+
+my $iof_fname = tmpnam();
+my $io_fh = IO::File->new($iof_fname, 'w')
+    or  die "Could not open $iof_fname for writing: $ERRNO,";
+
+my $tee = IO::Tee->new($wrap_fh, $io_fh);
+ok( $tee->print('1234567890') , 'print 10 characters');
+ok( $tee->close() , 'closed both files');
+
+cmp_ok( -s $wrap_fname , '==' , 10 , 'IO::Wrap wrote 10 chars');
+cmp_ok( -s $iof_fname , '==' , 10 , 'IO::File wrote 10 chars');
+
+unlink($wrap_fname, $wrap_fh);
+
+
+exit(0);


### PR DESCRIPTION
IO::Tee uses print as a function, thus the file handle must be a GLOB
reference. (The error message is "Not a GLOB reference...".) IO::Wrap
is a class with a print method, that should be usable as well.

In fact, with that change any class with file handle compatible methods
could be used with IO::Tee.